### PR TITLE
Fix ERC-20 withdraw error

### DIFF
--- a/dapp/src/services/Token.js
+++ b/dapp/src/services/Token.js
@@ -94,7 +94,7 @@
               count,
               Wallet.txDefaults({
                 gas: 500000,
-                gasPrice: wallet.txParams.gasPrice
+                gasPrice: Wallet.txParams.gasPrice
               }),
               options,
               cb);


### PR DESCRIPTION
As reported on Discord, withdrawing an ERC-20 token fails:

![image](https://user-images.githubusercontent.com/25791237/125575533-06c0f86b-536c-4ed5-a090-e88f1a4a5981.png)
![image](https://user-images.githubusercontent.com/25791237/125575560-b33476de-6071-467a-8352-bd7731204fce.png)

This fixes the issue.